### PR TITLE
Add AC3 to lookahead

### DIFF
--- a/lib/sports_manager/constraints/all_different_constraint.rb
+++ b/lib/sports_manager/constraints/all_different_constraint.rb
@@ -8,7 +8,9 @@ module SportsManager
       attr_reader :matches
 
       def self.for_tournament(tournament:, csp:)
-        csp.add_constraint(new(tournament.matches.values.flatten))
+        matches = tournament.matches.values.flatten
+
+        csp.add_constraint(new(matches))
       end
 
       def initialize(matches)

--- a/lib/sports_manager/constraints/match_constraint.rb
+++ b/lib/sports_manager/constraints/match_constraint.rb
@@ -10,9 +10,11 @@ module SportsManager
       def self.for_tournament(tournament:, csp:)
         tournament.matches.each do |(_category, matches)|
           matches.select(&:previous_matches?).each do |match|
-            csp.add_constraint(
-              new(target_match: match, matches: match.previous_matches)
-            )
+            match.previous_matches.each do |previous_match|
+              csp.add_constraint(
+                new(target_match: match, matches: [previous_match])
+              )
+            end
           end
         end
       end

--- a/lib/sports_manager/constraints/multi_category_constraint.rb
+++ b/lib/sports_manager/constraints/multi_category_constraint.rb
@@ -7,19 +7,22 @@ module SportsManager
                   :match_time, :break_time, :minimum_match_gap
 
       MINUTE = 60
+      IN_PAIRS = 2
 
       def self.for_tournament(tournament:, csp:)
         tournament.multi_tournament_participants.each do |participant|
           matches = tournament.find_participant_matches(participant)
 
-          constraint = new(
-            target_participant: participant,
-            matches: matches,
-            match_time: tournament.match_time,
-            break_time: tournament.break_time
-          )
+          matches.combination(IN_PAIRS) do |match1, match2|
+            constraint = new(
+              target_participant: participant,
+              matches: [match1, match2],
+              match_time: tournament.match_time,
+              break_time: tournament.break_time
+            )
 
-          csp.add_constraint(constraint)
+            csp.add_constraint(constraint)
+          end
         end
       end
 

--- a/lib/sports_manager/constraints/next_round_constraint.rb
+++ b/lib/sports_manager/constraints/next_round_constraint.rb
@@ -13,12 +13,14 @@ module SportsManager
           .matches.values.flatten
           .select(&:previous_matches?)
           .each do |match|
-            csp.add_constraint new(
-              target_match: match,
-              matches: match.previous_matches,
-              match_time: tournament.match_time,
-              break_time: tournament.break_time
-            )
+            match.previous_matches.each do |previous_match|
+              csp.add_constraint new(
+                target_match: match,
+                matches: [previous_match],
+                match_time: tournament.match_time,
+                break_time: tournament.break_time
+              )
+            end
           end
       end
 

--- a/lib/sports_manager/constraints/no_overlapping_constraint.rb
+++ b/lib/sports_manager/constraints/no_overlapping_constraint.rb
@@ -5,13 +5,17 @@ module SportsManager
     class NoOverlappingConstraint < ::CSP::Constraint
       attr_reader :matches, :match_time
 
+      IN_PAIRS = 2
+
       def self.for_tournament(tournament:, csp:)
-        csp.add_constraint(
-          new(
-            matches: tournament.matches.values.flatten,
-            match_time: tournament.match_time
+        matches = tournament.matches.values.flatten
+        match_time = tournament.match_time
+
+        matches.combination(IN_PAIRS) do |match1, match2|
+          csp.add_constraint(
+            new(matches: [match1, match2], match_time: match_time)
           )
-        )
+        end
       end
 
       def initialize(matches:, match_time:)

--- a/lib/sports_manager/tournament_generator.rb
+++ b/lib/sports_manager/tournament_generator.rb
@@ -22,7 +22,7 @@ module SportsManager
     extend Forwardable
 
     attr_reader :format, :tournament, :variables, :domains,
-                :ordering, :filtering, :csp
+                :ordering, :filtering, :lookahead, :csp
 
     attr_accessor :days, :subscriptions, :matches, :courts, :game_length, :rest_break, :single_day_matches,
                   :tournament_type
@@ -50,6 +50,7 @@ module SportsManager
       @matches = {}
       @ordering = Algorithms::Ordering::MultipleMatchesParticipant
       @filtering = Algorithms::Filtering::NoOverlap
+      @lookahead = CSP::Algorithms::Lookahead::Ac3
     end
 
     def add_day(day, start, finish)
@@ -153,6 +154,7 @@ module SportsManager
         .add_domains(domains)
         .add_ordering(ordering)
         .add_filtering(filtering)
+        .add_lookahead(lookahead)
         .add_constraint(Constraints::AllDifferentConstraint)
         .add_constraint(Constraints::NoOverlappingConstraint)
         .add_constraint(Constraints::MatchConstraint)

--- a/spec/tournament_generator_spec.rb
+++ b/spec/tournament_generator_spec.rb
@@ -843,5 +843,44 @@ RSpec.describe SportsManager::TournamentGenerator do
         )
       )
     end
+
+    context 'when problem has no solution' do
+      it 'test case' do
+        subscriptions = {
+          mens_single: [
+            { id: 1, name: 'João' },      { id: 2, name: 'Marcelo' },
+            { id: 3, name: 'José' },      { id: 4, name: 'Pedro' },
+            { id: 5, name: 'Carlos' },    { id: 6, name: 'Leandro' },
+            { id: 7, name: 'Leonardo' },  { id: 8, name: 'Cláudio' },
+            { id: 9, name: 'Alexandre' }, { id: 10, name: 'Daniel' },
+            { id: 11, name: 'Marcos' },   { id: 12, name: 'Henrique' }
+          ]
+        }
+        matches = {
+          mens_single: [
+            [1, 12],
+            [2, 11],
+            [3, 10],
+            [4, 9],
+            [5, 8],
+            [6, 7]
+          ]
+        }
+
+        result = SportsManager::TournamentGenerator
+          .new(format: :cli)
+          .add_days({ '2023-09-09': { start: 9, end: 12 } })
+          .add_courts(2)
+          .add_game_length(60)
+          .add_rest_break(10)
+          .enable_single_day_matches(true)
+          .add_subscriptions(subscriptions)
+          .single_elimination_algorithm
+          .add_matches(matches)
+          .call
+
+        expect(result.solutions).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
# Description
We've got a case where the problem had no solution but the algorithm kept running for too long due to the number o domains to check.

## Proposed Change
Adds an look ahead by default (AC3) to prune the domains. Also it changes the constraint to build in pairs of variables to allow the AC3 to run properly.


## Comments
We're are still going to make some changes to allow a better tinkering of the params, but for now this should do. 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have read the **CONTRIBUTING** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
