### PR TITLE
feat/add-timeout-configuration

### DIFF
--- a/lib/sports_manager/tournament_generator.rb
+++ b/lib/sports_manager/tournament_generator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'timeout'
+
 # rubocop:disable Metrics/AbcSize
 module SportsManager
   # Public:Tournament Solver
@@ -22,7 +24,7 @@ module SportsManager
     extend Forwardable
 
     attr_reader :format, :tournament, :variables, :domains,
-                :ordering, :filtering, :lookahead, :csp
+                :ordering, :filtering, :lookahead, :csp, :timeout
 
     attr_accessor :days, :subscriptions, :matches, :courts, :game_length, :rest_break, :single_day_matches,
                   :tournament_type
@@ -43,8 +45,9 @@ module SportsManager
         .call
     end
 
-    def initialize(format: :cli)
+    def initialize(format: :cli, timeout: nil)
       @format = format
+      @timeout = timeout
       @days = {}
       @subscriptions = {}
       @matches = {}
@@ -129,7 +132,7 @@ module SportsManager
     def call
       setup
 
-      solutions = csp.solve
+      solutions = Timeout.timeout(timeout) { csp.solve }
 
       TournamentSolution
         .new(tournament: tournament, solutions: solutions)


### PR DESCRIPTION
# Description
Timeout configuration, as it allows the user to set how long they are willing to wait for the problem to be solved. There are cases where the solution may take a few minutes, while in others it may take several hours. Therefore, we want to put the decision in the user's hands to define how long they want to wait. Additionally, even if this feature is implemented on the user side, the process will continue running in the background.

## Proposed Change
To address the issue of varying solution times, I propose adding a timeout configuration that enables users to set a custom timeout period. This feature allows users to define how long they are willing to wait for the problem to be solved, providing more control and flexibility.

The following behaviors were added:

A timeout configuration option was introduced, allowing users to set a custom timeout period.
The system will respect the user-defined timeout period and terminate the process if the solution is not found within the specified time frame.

## Comments
<!--
Feel free to use this space to add anything you consider relevant but doesn't belong in the other topics, such as:
- Reference of other projects that had the same problem or uses the same solution.
- Alternative solutions that were considered (and possible problems with them).
- Possible issues or scenarios that we should consider in the future.
- What type of change may break this solution.
-->

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have read the **CONTRIBUTING** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
