### PR TITLE
Allow any valid hash key for subscription

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sports-manager (0.1.0)
+    sports-manager (0.1.1)
       csp-resolver (~> 0.0.1)
 
 GEM

--- a/lib/sports_manager/tournament_solution/solution.rb
+++ b/lib/sports_manager/tournament_solution/solution.rb
@@ -43,7 +43,11 @@ module SportsManager
       end
 
       def build_category_acronym(category, size = 2, reference = {})
-        parts = category.to_s.split(CATEGORY_SEPARATOR)
+        category = category.to_s
+        category_middle = category.length / 2
+
+        parts = category.split(CATEGORY_SEPARATOR) if category.to_s.match?(/#{CATEGORY_SEPARATOR}/)
+        parts ||= [category[0..category_middle], category[category_middle..-1]]
         interval = (0..size)
 
         build_acronym(parts, interval, reference)

--- a/lib/sports_manager/version.rb
+++ b/lib/sports_manager/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SportsManager
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/tournament_solution/solution_spec.rb
+++ b/spec/tournament_solution/solution_spec.rb
@@ -67,7 +67,9 @@ RSpec.describe SportsManager::TournamentSolution::Solution do
         instance_double(SportsManager::TournamentSolution::Fixture, category: :mixed_single),
         instance_double(SportsManager::TournamentSolution::Fixture, category: :mixed_single),
         instance_double(SportsManager::TournamentSolution::Fixture, category: :men_single),
-        instance_double(SportsManager::TournamentSolution::Fixture, category: :women_double)
+        instance_double(SportsManager::TournamentSolution::Fixture, category: :women_double),
+        instance_double(SportsManager::TournamentSolution::Fixture, category: :dogdouble),
+        instance_double(SportsManager::TournamentSolution::Fixture, category: :d),
       ]
 
       solution = described_class.new(fixtures)
@@ -75,7 +77,9 @@ RSpec.describe SportsManager::TournamentSolution::Solution do
       expect(solution.acronyms).to eq({
         mixed_single: 'ms',
         men_single: 'mesi',
-        women_double: 'wd'
+        women_double: 'wd',
+        dogdouble: 'do',
+        d: 'dd'
       })
     end
 

--- a/spec/tournament_solution/solution_spec.rb
+++ b/spec/tournament_solution/solution_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe SportsManager::TournamentSolution::Solution do
         instance_double(SportsManager::TournamentSolution::Fixture, category: :men_single),
         instance_double(SportsManager::TournamentSolution::Fixture, category: :women_double),
         instance_double(SportsManager::TournamentSolution::Fixture, category: :dogdouble),
-        instance_double(SportsManager::TournamentSolution::Fixture, category: :d),
+        instance_double(SportsManager::TournamentSolution::Fixture, category: :d)
       ]
 
       solution = described_class.new(fixtures)


### PR DESCRIPTION
# Description
This PR solves the issue where an error is raised when a hash key for subscriptions without the '\_' character is passed.

Fixes #2

## Proposed Change
When a hash key does not contain the '\_' character, the program now splits the hash key in the middle instead of trying to split it by the '\_' separator.

## Comments
It's a very simples solution that just fix the raise problem. It may not give the best acronyms for the keys without the '\_' separator. But if you want to you can just use the '\_' separator. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have read the **CONTRIBUTING** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
